### PR TITLE
add: book title and author info to edit page

### DIFF
--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -4,6 +4,8 @@
   <% if (locals.data) {  %>
     <div class="form-container">
       <form class="note-form edit-form" action="/notes/<%= data.id %>/edit" method="post">
+        <p><strong>Book Title: </strong><br><%= data.book_title %></p>
+        <p><strong>Author: </strong><br><%= data.book_author %></p>
         <input type="hidden" name="updatedItemId" value="<%= data.id %>" required>
         <label for="rating"><strong>Rating: </strong></label>
         <select type="radio" id="rating" class="form-basic" name="updatedRating" value="<%= data.rating %>" required>


### PR DESCRIPTION
## Issue
- https://github.com/RLMP44/book-basho/issues/4

## Done
- Title and author info added to edit page to eliminate user confusion.
<img width="1071" height="825" alt="image" src="https://github.com/user-attachments/assets/ab58e706-9571-4e47-86d0-30b4f8c888bf" />


## To-Do
- None