### PR TITLE
2/smooth grid layout

### DIFF
--- a/public/styles/button.css
+++ b/public/styles/button.css
@@ -36,6 +36,7 @@
 
 .searchbar-button {
   margin: 0rem .5rem;
+  padding: .25rem 1rem;
 }
 
 .edit-button {

--- a/public/styles/card.css
+++ b/public/styles/card.css
@@ -23,43 +23,44 @@
   grid-area: 1 / 2 / 2 / 3;
   display: flex;
   justify-self: flex-end;
+  text-align: end;
 }
 
 .card-buttons {
   grid-area: 1 / 3 / 2 / 4;
   display: flex;
   justify-self: flex-end;
-  align-self: center;
+  align-self: flex-start;
   gap: 8px;
 }
 
 .card-title-author {
-  grid-area: 2 / 1 / 3 / 3;
+  grid-area: 2 / 1 / 3 / 2;
   display: flex;
   flex-direction: column;
 }
 
 .card-note {
-  grid-area: 3 / 1 / 5 / 3;
+  grid-area: 3 / 1 / 4 / 4;
   align-self: flex-start;
 }
 
 .card-cover {
-  display: flex;
-  justify-self: flex-end;
   max-width: 155px;
   max-height: 240px;
   min-height: 175px;
-  grid-area: 2 / 3 / 4 / -1;
-  align-self: flex-end;
   width: 95%;
   height: auto;
+  margin-right: 1rem;
+  margin-bottom: 1rem;
+  float: left;
 }
 
 .card-year {
   grid-area: 2 / 2 / 3 / 3;
   display: flex;
   justify-self: flex-end;
+  text-align: end;
 }
 
 .search-book-card {

--- a/public/styles/queries.css
+++ b/public/styles/queries.css
@@ -84,48 +84,53 @@
   }
 
   .card-read {
-    grid-area: 4 / 1 / 5 / 2;
+    grid-area: 3 / 1 / 4 / 2;
     margin: .25rem 0rem;
     justify-self: flex-start;
+    text-align: start;
   }
 
   .card-buttons {
     grid-area: 1 / 2 / 2 / 3;
     display: flex;
     justify-self: flex-end;
-    align-self: center;
     gap: 8px;
   }
 
   .card-title-author {
-    grid-area: 2 / 1 / 3 / 3;
+    grid-area: 2 / 1 / 3 / 2;
+  }
+
+  .card-author {
+    margin-bottom: 0rem;
   }
 
   .card-note {
-    grid-area: 3 / 1 / 4 / 3;
+    grid-area: 4 / 1 / 5 / 3;
   }
 
   .card-cover {
     max-width: 115px;
     max-height: 175px;
-    grid-area: 4 / 2 / 7 / 3;
+    grid-area: 2 / 2 / 5 / 3;
     align-self: flex-start;
     width: auto;
     height: auto;
   }
 
   .card-year {
-    grid-area: 5 / 1 / 6 / 2;
-    justify-self: flex-start;
+    grid-area: 2 / 2 / 3 / 3;
+    justify-self: flex-end;
   }
 
   .note-form {
-    grid-area: 6 / 1 / 7 / 2;
+    grid-area: 5 / 1 / 6 / 3;
     justify-self: flex-start;
   }
 
   .card-button {
-    padding: 13px 50% 13px;
+    padding: 13px 100% 13px;
+    font-size: 12px;
   }
 }
 
@@ -134,6 +139,25 @@
   /* Styles for small tablets and phones */
   .title-text {
     font-size: 2.5rem;
+  }
+
+  .main-content {
+    grid-template-columns: 50% 50%;
+    padding: 1rem;
+    background-size: 300px auto;
+  }
+
+  .search-bar, .sidebar {
+    background-color: var(--main-green-transparent);
+  }
+
+  .sidebar {
+    grid-area: 1 / 2.5 / 2 / 4;
+    margin: 0rem 1rem 1rem 1rem;
+  }
+
+  .search-bar {
+    grid-area: 2 / 1 / 3 / 4;
   }
 }
 
@@ -220,7 +244,7 @@
   }
 
   .note-form {
-    grid-area: 5 / 2 / 6 / 3;
+    grid-area: 5 / 3 / 6 / 4;
   }
 }
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -30,10 +30,12 @@
             </div>
             <div class="card-title-author">
               <p class="text-black mb-0 minimize-txt"><strong><%= note.book_title %></strong></p>
-              <p class="text-black minimize-txt"><em><%= note.book_author %></em></p>
+              <p class="text-black card-author minimize-txt"><em><%= note.book_author %></em></p>
             </div>
-            <p class="text-black mb-0 card-note minimize-txt"><%= note.summary %></p>
-            <img class="card-cover" src="<%= note.book_cover %>" alt="book cover">
+            <p class="text-black mb-0 card-note minimize-txt">
+              <img class="card-cover" src="<%= note.book_cover %>" alt="book cover">
+              <%= note.summary %>
+            </p>
             <p class="text-grey mb-0 card-year minimize-txt">Published: <%= note.book_year %></p>
             <form class="note-form" action="/notes/<%= note.id %>" method="get">
               <button class="main-button btn-lg card-button" type="submit" alt="View notes">Notes</button>

--- a/views/show.ejs
+++ b/views/show.ejs
@@ -24,10 +24,12 @@
         </div>
         <div class="card-title-author">
           <p class="text-black mb-0"><strong><%= data.book_title %></strong></p>
-          <p class="text-black"><em><%= data.book_author %></em></p>
+          <p class="text-black card-author"><em><%= data.book_author %></em></p>
         </div>
-        <p class="text-black mb-0 card-note"><%= data.note %></p>
-        <img class="card-cover" src="<%= data.book_cover %>" alt="book cover">
+        <p class="text-black mb-0 card-note">
+          <img class="card-cover" src="<%= data.book_cover %>" alt="book cover">
+          <%= data.note %>
+        </p>
         <p class="text-grey mb-0 card-year">Published: <%= data.book_year %></p>
       </div>
     </div>


### PR DESCRIPTION
## Issue 
- #2 

## Done
- Move book cover into book note paragraph element, display as float left to incorporate with text and eliminate blank spaces
- Adjust book year, book read date, and book notes to follow suit
- Make consistent across different screen sizes

-- Small screen, show page
<img width="538" height="831" alt="image" src="https://github.com/user-attachments/assets/f1a5f49b-b547-4ae2-ade6-f9ecefd96e9c" />
-- Small screen, index page
<img width="347" height="525" alt="image" src="https://github.com/user-attachments/assets/c8f83919-43a0-4b30-9bbf-c7ed16ce845c" />
-- Med screen, show page
<img width="701" height="659" alt="image" src="https://github.com/user-attachments/assets/d41a0c4f-a46e-414a-9a0b-f97caa43d8a0" />
-- Med screen, index page
<img width="549" height="570" alt="image" src="https://github.com/user-attachments/assets/111ebba5-978b-4b74-a8e4-7b56d46b6012" />
-- Large screen, show page
<img width="1459" height="472" alt="image" src="https://github.com/user-attachments/assets/425f230a-ac77-4bf8-a004-adb167f7b045" />
-- Large screen, index page
<img width="1129" height="512" alt="image" src="https://github.com/user-attachments/assets/06a87e92-3d72-4e63-a977-5ce961155460" />


